### PR TITLE
Add info how to apply Quadrant using plugins DSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,28 @@ and then apply it in the `build.gradle` file of one of your `Android` modules (`
 apply plugin: "com.gaelmarhic.quadrant"
 ``` 
 
-If you are using a `Kotlin` script or prefer to use the `Plugins DSL`, please check [here](https://plugins.gradle.org/plugin/com.gaelmarhic.quadrant) how to do it.
+If you prefer to use the `Plugins DSL`, you have to edit your `settings.gradle`, first, and set the repositories where Gradle should resolve plugins from (needs to be at top of file):
+
+```groovy
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+    }
+}
+```
+
+This tells Gradle to resolve plugins from the Gradle plugin repo and from the Google maven repo. This is necessary, because Quadrant depends on the Android Gradle plugin, which can only be resolved from the latter one.
+
+Aftwards you can use the Quadrant plugin with:
+
+```groovy
+plugins {
+    id "com.gaelmarhic.quadrant" version "$version"
+}
+```
+
+
 
 **ATTENTION**: It is strongly recommended to apply Quadrant to only one module of your project in order to not harm your build time. 
 As an example, you could create a `navigation` module which will contain all your navigation-related code and apply Quadrant only to that one.


### PR DESCRIPTION
Hey,

as mentioned in #1 to apply Quadrant with the plugins DSL one has to specify the plugin repos in `settings.gradle`.  `gradlePluginPortal()` **and**  `google()` need to be added. Only adding `google()`, so Gradle could resolve the dependency on the AGP, would lead to another error, because Gradle wouldn't look into the Gradle plugin repo anymore and couldn't find Quadrant.

Afaik there is no way to reference the Google maven from the plugin, so it could work without adding the repos manually.