### PR TITLE
Support package namespace when generating QuadrantConstants

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ There is no magic here. Quadrant simply parses your entire project's `AndroidMan
 ```kotlin
 object QuadrantConstants {
   
-  const val MAIN_ACTIVITY: String = "com.gaelmarhic.quadrant.MainActivity"
+  const val com_gaelmarhic_quadrant_MainActivity: String = "com.gaelmarhic.quadrant.MainActivity"
 
-  const val SECONDARY_ACTIVITY: String = "com.gaelmarhic.quadrant.SecondaryActivity"
+  const val com_gaelmarhic_quadrant_SecondaryActivity: String = "com.gaelmarhic.quadrant.SecondaryActivity"
 
-  const val TERTIARY_ACTIVITY: String = "com.gaelmarhic.quadrant.TertiaryActivity"
+  const val com_gaelmarhic_quadrant_TertiaryActivity: String = "com.gaelmarhic.quadrant.TertiaryActivity"
 }
 ```
 
@@ -22,7 +22,7 @@ This way you do not need any direct dependency to any `Activity` class inside of
 
 ```kotlin
 val intent = Intent()
-intent.setClassName(context, QuadrantConstants.MAIN_ACTIVITY)
+intent.setClassName(context, QuadrantConstants.com_gaelmarhic_quadrant_MainActivity)
 startActivity(intent)
 ``` 
 

--- a/src/main/kotlin/com/gaelmarhic/quadrant/constants/QuadrantConstants.kt
+++ b/src/main/kotlin/com/gaelmarhic/quadrant/constants/QuadrantConstants.kt
@@ -32,4 +32,5 @@ object Miscellaneous {
 
     const val EMPTY_SEPARATOR = ""
     const val PACKAGE_SEPARATOR = "."
+    const val CLASS_NAME_SEPARATOR = "_"
 }

--- a/src/main/kotlin/com/gaelmarhic/quadrant/extensions/QuadrantConfigurationExtension.kt
+++ b/src/main/kotlin/com/gaelmarhic/quadrant/extensions/QuadrantConfigurationExtension.kt
@@ -3,4 +3,5 @@ package com.gaelmarhic.quadrant.extensions
 open class QuadrantConfigurationExtension {
     var generateByDefault: Boolean = true
     var perModule: Boolean = false
+    var packageNamespaceEnabled: Boolean = true
 }

--- a/src/main/kotlin/com/gaelmarhic/quadrant/helpers/ConstantFileDeterminationHelper.kt
+++ b/src/main/kotlin/com/gaelmarhic/quadrant/helpers/ConstantFileDeterminationHelper.kt
@@ -1,12 +1,14 @@
 package com.gaelmarhic.quadrant.helpers
 
 import com.gaelmarhic.quadrant.constants.GeneralConstants.PLUGIN_NAME
+import com.gaelmarhic.quadrant.constants.Miscellaneous.CLASS_NAME_SEPARATOR
 import com.gaelmarhic.quadrant.constants.Miscellaneous.EMPTY_SEPARATOR
 import com.gaelmarhic.quadrant.constants.Miscellaneous.PACKAGE_SEPARATOR
 import com.gaelmarhic.quadrant.extensions.QuadrantConfigurationExtension
 import com.gaelmarhic.quadrant.models.generation.ConstantToBeGenerated
 import com.gaelmarhic.quadrant.models.generation.FileToBeGenerated
 import com.gaelmarhic.quadrant.models.modules.FilteredModule
+import java.util.*
 
 class ConstantFileDeterminationHelper(
     private val configurationExtension: QuadrantConfigurationExtension
@@ -48,11 +50,14 @@ class ConstantFileDeterminationHelper(
         value = this
     )
 
-    private fun String.formatConstantName() =
+    private fun String.formatConstantName() = if (configurationExtension.packageNamespaceEnabled) {
+        replace(PACKAGE_SEPARATOR, CLASS_NAME_SEPARATOR, true)
+    } else {
         split(PACKAGE_SEPARATOR)
             .last()
             .mapIndexed { index, letter -> formatLetter(index, letter) }
             .joinToString(EMPTY_SEPARATOR)
+    }
 
     private fun formatLetter(index: Int, letter: Char) =
         if (letter.isUpperCase() && index != 0) "_$letter" else letter.toUpperCase().toString()

--- a/src/test/kotlin/com/gaelmarhic/quadrant/helpers/ConstantFileDeterminationHelperTest.kt
+++ b/src/test/kotlin/com/gaelmarhic/quadrant/helpers/ConstantFileDeterminationHelperTest.kt
@@ -12,7 +12,9 @@ import org.junit.jupiter.api.Test
 
 internal class ConstantFileDeterminationHelperTest {
 
-    private val configurationExtension = QuadrantConfigurationExtension()
+    private val configurationExtension = QuadrantConfigurationExtension().apply {
+        namespaceEnabled = true
+    }
 
     private val constantFileDeterminationHelper = ConstantFileDeterminationHelper(
         configurationExtension = configurationExtension


### PR DESCRIPTION
Draft proposal to support package namespace with Quadrant. For discussion, check #5.

When generating constants, Quadrant would respect the package namespace generating full qualified constant names: `com.gaelmarhic.quadrant.ModuleOneFirstActivity` -> `com_gaelmarhic_quadrant_ModuleTwoSecondActivity`. Now, quadrant completely remove the package namespace and generate a single name as: "MODULE_ONE_FIRST_ACTIVITY" which might cause package conflicts.

The code here already generate the proposed format but I will be waiting @gaelmarhic buy-in before adding more tests for the new case as there are few questions that need to be answered (what would be the format of those package namespace names? should we keep the backward compatibility or not? etc).

Fix #5