### PR TITLE
Add support for Gradle Configuration Cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ For some reason, in that case, `Gradle's Configuration Cache` may make the build
 
 In order to overcome this issue, you simply need to invalidate that cache manually by running:
 ```
- rm -rf .gradle/configuration-cache
+rm -rf .gradle/configuration-cache
 ```
 
 License

--- a/README.md
+++ b/README.md
@@ -227,23 +227,6 @@ quadrantConfig {
 
 <img src="https://user-images.githubusercontent.com/16627604/75117768-b15bcd00-5674-11ea-8a46-16ec3db97162.png" width=300/>
 
-Troubleshooting
------------------
-
-If you modify `Quadrant`'s configuration, in any of your `build.gradle` files where it is applied, when having `Gradle's Configuration Cache` enabled and rebuild, you may sometimes get an error similar to this one:
-```
-> Task :app:compileDebugKotlin FAILED
-e: Source file or directory not found: /Users/MyUser/Desktop/MyApp/app/build/generated/source/quadrant/com/gaelmarhic/quadrant/QuadrantConfig.kt
-```
-
-This happens because, depending on the configuration you have modified, `Quadrant` may not generate anymore some files that were previously generated.
-For some reason, in that case, `Gradle's Configuration Cache` may make the build fail.
-
-In order to overcome this issue, you simply need to invalidate that cache manually by running:
-```
-rm -rf .gradle/configuration-cache
-```
-
 License
 -------
 

--- a/README.md
+++ b/README.md
@@ -227,6 +227,23 @@ quadrantConfig {
 
 <img src="https://user-images.githubusercontent.com/16627604/75117768-b15bcd00-5674-11ea-8a46-16ec3db97162.png" width=300/>
 
+Troubleshooting
+-----------------
+
+If you modify `Quadrant`'s configuration, in any of your `build.gradle` files where it is applied, when having `Gradle's Configuration Cache` enabled and rebuild, you may sometimes get an error similar to this one:
+```
+> Task :app:compileDebugKotlin FAILED
+e: Source file or directory not found: /Users/MyUser/Desktop/MyApp/app/build/generated/source/quadrant/com/gaelmarhic/quadrant/QuadrantConfig.kt
+```
+
+This happens because, depending on the configuration you have modified, `Quadrant` may not generate anymore some files that were previously generated.
+For some reason, in that case, `Gradle's Configuration Cache` may make the build fail.
+
+In order to overcome this issue, you simply need to invalidate that cache manually by running:
+```
+ rm -rf .gradle/configuration-cache
+```
+
 License
 -------
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,6 @@ plugins {
 }
 
 repositories {
-    jcenter()
     mavenCentral()
     google()
 }

--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ dependencies {
     implementation Dependencies.androidPlugin
     implementation Dependencies.kotlinStandardLibrary
     implementation Dependencies.kotlinPoet
+    implementation Dependencies.jacksonXml
 
     // Testing
     testImplementation Dependencies.jUnit5Api

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -3,5 +3,5 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -4,6 +4,7 @@ object Dependencies {
     const val androidPlugin = "com.android.tools.build:gradle:${Versions.androidPlugin}"
     const val kotlinStandardLibrary = "org.jetbrains.kotlin:kotlin-stdlib"
     const val kotlinPoet = "com.squareup:kotlinpoet:${Versions.kotlinPoet}"
+    const val jacksonXml = "com.fasterxml.jackson.dataformat:jackson-dataformat-xml:${Versions.jackson}"
 
     // Testing
     const val jUnit5Api = "org.junit.jupiter:junit-jupiter-api:${Versions.jUnit5}"

--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -3,6 +3,7 @@ object Versions {
     // Plugin
     const val androidPlugin = "3.5.0"
     const val kotlinPoet = "1.4.4"
+    const val jackson = "2.12.3"
 
     // Testing
     const val jUnit5 = "5.3.1"

--- a/src/main/kotlin/com/gaelmarhic/quadrant/QuadrantPlugin.kt
+++ b/src/main/kotlin/com/gaelmarhic/quadrant/QuadrantPlugin.kt
@@ -39,13 +39,8 @@ class QuadrantPlugin : Plugin<Project> {
         val variants = block(extension)
         val mainSourceSet = extension.sourceSet(MAIN_SOURCE_SET)
 
-        registerConfigurationExtension()
         registerTask(createGenerateActivityClassNameConstantsTask(), variants)
         addTargetDirectoryToSourceSet(mainSourceSet)
-    }
-
-    private fun Project.registerConfigurationExtension() {
-        extensions.create(PLUGIN_CONFIG, QuadrantConfigurationExtension::class.java)
     }
 
     private fun <V : BaseVariant> Project.registerTask(
@@ -76,9 +71,11 @@ class QuadrantPlugin : Plugin<Project> {
     private fun Project.createGenerateActivityClassNameConstantsTask(): Task {
         val taskType = GenerateActivityClassNameConstants::class.java
         val taskName = taskType.simpleName.decapitalize()
+        val extension = registerConfigurationExtension()
         return tasks.create(taskName, taskType) { task ->
             val rawModuleList = retrieveRawModuleList(this)
             task.apply {
+                configurationExtension.set(extension)
                 buildScript.set(buildFile)
                 manifestFiles.set(rawModuleList.flatMap { it.manifestFiles })
                 targetDirectory.set(buildDir.resolve(TARGET_DIRECTORY))
@@ -86,6 +83,9 @@ class QuadrantPlugin : Plugin<Project> {
             }
         }
     }
+
+    private fun Project.registerConfigurationExtension() =
+        extensions.create(PLUGIN_CONFIG, QuadrantConfigurationExtension::class.java)
 
     private fun retrieveRawModuleList(project: Project) =
         project // This project is the project of the module where the plugin is applied.

--- a/src/main/kotlin/com/gaelmarhic/quadrant/extensions/QuadrantConfigurationExtension.kt
+++ b/src/main/kotlin/com/gaelmarhic/quadrant/extensions/QuadrantConfigurationExtension.kt
@@ -1,6 +1,13 @@
 package com.gaelmarhic.quadrant.extensions
 
-open class QuadrantConfigurationExtension {
+import org.gradle.api.tasks.Input
+import java.io.Serializable
+
+open class QuadrantConfigurationExtension : Serializable {
+
+    @get:Input
     var generateByDefault: Boolean = true
+
+    @get:Input
     var perModule: Boolean = false
 }

--- a/src/main/kotlin/com/gaelmarhic/quadrant/helpers/ConstantGenerationHelper.kt
+++ b/src/main/kotlin/com/gaelmarhic/quadrant/helpers/ConstantGenerationHelper.kt
@@ -13,6 +13,7 @@ class ConstantGenerationHelper(
 ) {
 
     fun generate(filesToBeGenerated: List<FileToBeGenerated>) {
+        targetDirectory.deleteRecursively()
         filesToBeGenerated.forEach { it.generate() }
     }
 

--- a/src/main/kotlin/com/gaelmarhic/quadrant/helpers/ManifestParsingHelper.kt
+++ b/src/main/kotlin/com/gaelmarhic/quadrant/helpers/ManifestParsingHelper.kt
@@ -11,7 +11,7 @@ import java.io.File
 
 class ManifestParsingHelper {
 
-    private val xmlMapper by lazy { initXmlMapper() }
+    private val xmlMapper = initXmlMapper()
 
     fun parse(rawModules: List<RawModule>) =
         rawModules

--- a/src/main/kotlin/com/gaelmarhic/quadrant/helpers/ManifestParsingHelper.kt
+++ b/src/main/kotlin/com/gaelmarhic/quadrant/helpers/ManifestParsingHelper.kt
@@ -1,19 +1,27 @@
 package com.gaelmarhic.quadrant.helpers
 
+import com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES
+import com.fasterxml.jackson.dataformat.xml.XmlMapper
+import com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector
 import com.gaelmarhic.quadrant.models.manifest.Manifest
 import com.gaelmarhic.quadrant.models.modules.ParsedManifest
 import com.gaelmarhic.quadrant.models.modules.ParsedModule
 import com.gaelmarhic.quadrant.models.modules.RawModule
 import java.io.File
-import javax.xml.bind.JAXBContext
 
 class ManifestParsingHelper {
 
-    private val jaxbUnMarshaller by lazy { JAXBContext.newInstance(Manifest::class.java).createUnmarshaller() }
+    private val xmlMapper by lazy { initXmlMapper() }
 
     fun parse(rawModules: List<RawModule>) =
         rawModules
             .map { it.parse() }
+
+    private fun initXmlMapper() =
+        XmlMapper().apply {
+            setAnnotationIntrospector(JaxbAnnotationIntrospector(typeFactory))
+            configure(FAIL_ON_UNKNOWN_PROPERTIES, false)
+        }
 
     private fun RawModule.parse() = ParsedModule(
         name = name,
@@ -24,9 +32,8 @@ class ManifestParsingHelper {
         .map { it.toManifest() }
 
     private fun File.toManifest() =
-        jaxbUnMarshaller
-            .unmarshal(this)
-            .let { it as Manifest }
+        xmlMapper
+            .readValue(this, Manifest::class.java)
             .let {
                 ParsedManifest(
                     path = absolutePath,

--- a/src/main/kotlin/com/gaelmarhic/quadrant/models/modules/RawModule.kt
+++ b/src/main/kotlin/com/gaelmarhic/quadrant/models/modules/RawModule.kt
@@ -1,8 +1,9 @@
 package com.gaelmarhic.quadrant.models.modules
 
 import java.io.File
+import java.io.Serializable
 
 data class RawModule(
     val name: String,
     val manifestFiles: List<File>
-)
+) : Serializable

--- a/src/main/kotlin/com/gaelmarhic/quadrant/tasks/GenerateActivityClassNameConstants.kt
+++ b/src/main/kotlin/com/gaelmarhic/quadrant/tasks/GenerateActivityClassNameConstants.kt
@@ -1,6 +1,5 @@
 package com.gaelmarhic.quadrant.tasks
 
-import com.gaelmarhic.quadrant.constants.GeneralConstants.PLUGIN_CONFIG
 import com.gaelmarhic.quadrant.constants.GeneralConstants.PLUGIN_NAME
 import com.gaelmarhic.quadrant.extensions.QuadrantConfigurationExtension
 import com.gaelmarhic.quadrant.helpers.*
@@ -10,12 +9,14 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
 import org.gradle.api.tasks.*
 import java.io.File
 
 abstract class GenerateActivityClassNameConstants : DefaultTask() {
 
-    private val configurationExtension = retrieveConfigurationExtension()
+    @get:Nested
+    abstract val configurationExtension: Property<QuadrantConfigurationExtension>
 
     @get:InputFile
     abstract val buildScript: RegularFileProperty
@@ -39,17 +40,14 @@ abstract class GenerateActivityClassNameConstants : DefaultTask() {
         initProcessor().process(rawModules.get())
     }
 
-    private fun retrieveConfigurationExtension() =
-        project.extensions.findByName(PLUGIN_CONFIG) as QuadrantConfigurationExtension
-
     private fun initProcessor() = GenerateActivityClassNameConstantProcessor(
         manifestParsingHelper = ManifestParsingHelper(),
         manifestVerificationHelper = ManifestVerificationHelper(),
         activityFilteringHelper = ActivityFilteringHelper(
-            configurationExtension = configurationExtension
+            configurationExtension = configurationExtension.get()
         ),
         constantFileDeterminationHelper = ConstantFileDeterminationHelper(
-            configurationExtension = configurationExtension
+            configurationExtension = configurationExtension.get()
         ),
         constantGenerationHelper = ConstantGenerationHelper(targetDirectory.get().asFile)
     )

--- a/src/main/kotlin/com/gaelmarhic/quadrant/tasks/GenerateActivityClassNameConstants.kt
+++ b/src/main/kotlin/com/gaelmarhic/quadrant/tasks/GenerateActivityClassNameConstants.kt
@@ -17,11 +17,11 @@ import java.io.File
 
 open class GenerateActivityClassNameConstants : DefaultTask() {
 
-    private val configurationExtension by lazy { retrieveConfigurationExtension() }
+    private val configurationExtension = retrieveConfigurationExtension()
 
-    private val rawModules by lazy { retrieveRawModules() }
+    private val rawModules = retrieveRawModules()
 
-    private val processor by lazy { initProcessor() }
+    private val processor = initProcessor()
 
     @InputFile
     val buildScript = project.buildFile

--- a/src/test/resources/manifest1/AndroidManifest.xml
+++ b/src/test/resources/manifest1/AndroidManifest.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <application>
+    <application
+            android:allowBackup="true"
+            android:supportsRtl="true">
 
         <activity android:name="com.gaelmarhic.quadrant.Manifest1Activity1">
 

--- a/src/test/resources/manifest2/AndroidManifest.xml
+++ b/src/test/resources/manifest2/AndroidManifest.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <application>
+    <application
+            android:allowBackup="true"
+            android:supportsRtl="true">
 
         <activity android:name="com.gaelmarhic.quadrant.Manifest2Activity1"/>
 


### PR DESCRIPTION
This PR is aiming at fixing the issue described here : #7.

The aforementioned issue happens because, for some reason, JAXB-API cannot be found on module path or classpath, which seems to happen when `Quadrant` is being used on projects targeting JDK 11 and with `Gradle's Configuration Cache` enabled.

In order to avoid this, JAXB has been dropped and replaced by Jackson, in order to parse XML.

Once this issue fixed, the compilation kept throwing a bunch of other exceptions related to `Gradle's Configuration Cache`. 
In order to make it work, the following has been done:
- Removed usages of `by lazy`.
- Lifted usages of Gradle's `Project` API from the `Task` to the `Plugin`.
