### PR TITLE
Remove usage of Jackson and go back to JAXB

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,6 @@ dependencies {
     implementation Dependencies.androidPlugin
     implementation Dependencies.kotlinStandardLibrary
     implementation Dependencies.kotlinPoet
-    implementation Dependencies.jacksonXml
 
     // Testing
     testImplementation Dependencies.jUnit5Api

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -4,7 +4,6 @@ object Dependencies {
     const val androidPlugin = "com.android.tools.build:gradle:${Versions.androidPlugin}"
     const val kotlinStandardLibrary = "org.jetbrains.kotlin:kotlin-stdlib"
     const val kotlinPoet = "com.squareup:kotlinpoet:${Versions.kotlinPoet}"
-    const val jacksonXml = "com.fasterxml.jackson.dataformat:jackson-dataformat-xml:${Versions.jackson}"
 
     // Testing
     const val jUnit5Api = "org.junit.jupiter:junit-jupiter-api:${Versions.jUnit5}"

--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -3,7 +3,6 @@ object Versions {
     // Plugin
     const val androidPlugin = "3.5.0"
     const val kotlinPoet = "1.4.4"
-    const val jackson = "2.12.3"
 
     // Testing
     const val jUnit5 = "5.3.1"


### PR DESCRIPTION
In a previous PR (#8 ), `JAXB` was replaced by `Jackson` in order to parse `XML`.

That change  was actually not necessary but also introduced the bug described in #9.

For this reason, this PR removes the usage of `Jackson` and goes back to using `JAXB`.