### PR TITLE
build: declare dependency from KSP

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id "org.jetbrains.kotlin.jvm" version "1.4.0"
     id "com.gradle.plugin-publish" version "0.11.0"
     id 'java-gradle-plugin'
-    id "maven"
+    id "maven-publish"
 }
 
 repositories {
@@ -35,10 +35,10 @@ compileTestKotlin {
 group = "com.gaelmarhic"
 version = "1.7"
 
-uploadArchives {
+publishing {
     repositories {
-        mavenDeployer {
-            repository(url: uri('mavenrepo'))
+        maven {
+            url = uri('mavenrepo')
         }
     }
 }

--- a/src/main/kotlin/com/gaelmarhic/quadrant/QuadrantPlugin.kt
+++ b/src/main/kotlin/com/gaelmarhic/quadrant/QuadrantPlugin.kt
@@ -107,8 +107,13 @@ class QuadrantPlugin : Plugin<Project> {
 
     private fun BaseExtension.sourceSet(name: String) = sourceSets.getByName(name)
 
-    private fun <T : BaseVariant> Task.isCompileKotlinTask(variant: T) =
-        name == "compile${variant.name.capitalize()}Kotlin"
+    private fun <T : BaseVariant> Task.isCompileKotlinTask(variant: T): Boolean {
+        val variantName = variant.name.capitalize()
+        return name in listOf(
+            "compile${variantName}Kotlin",
+            "ksp${variantName}Kotlin",
+        )
+    }
 
     companion object {
 


### PR DESCRIPTION
## Overview:

I find this plugin helpful while I migrate my app to a single-activity architecture. I use KSP for annotation processing but the build fails due to a missing dependency declaration.

```
* What went wrong:
A problem was found with the configuration of task ':<my-module>:kspDebugKotlin' (type 'KspTaskJvm').
  - Gradle detected a problem with the following location: '<my-module-path>/build/generated/source/quadrant'.
    
    Reason: Task ':<my-module>:kspDebugKotlin' uses this output of task ':<my-module>:generateActivityClassNameConstants' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.
    
    Possible solutions:
      1. Declare task ':<my-module>:generateActivityClassNameConstants' as an input of ':<my-module>:kspDebugKotlin'.
      2. Declare an explicit dependency on ':<my-module>:generateActivityClassNameConstants' from ':<my-module>:kspDebugKotlin' using Task#dependsOn.
      3. Declare an explicit dependency on ':<my-module>:generateActivityClassNameConstants' from ':<my-module>:kspDebugKotlin' using Task#mustRunAfter.
    
    For more information, please refer to https://docs.gradle.org/8.4/userguide/validation_problems.html#implicit_dependency in the Gradle documentation.
```

Dear @gaelmarhic, I don't know if you still maintain this repository but if you can have time to look at this PR, it's highly appreciated.