### PR TITLE
fix: register extension before evaluated

### DIFF
--- a/src/main/kotlin/com/gaelmarhic/quadrant/QuadrantPlugin.kt
+++ b/src/main/kotlin/com/gaelmarhic/quadrant/QuadrantPlugin.kt
@@ -38,9 +38,11 @@ class QuadrantPlugin : Plugin<Project> {
         val extension = getExtension(extensionType)
         val variants = block(extension)
         val mainSourceSet = extension.sourceSet(MAIN_SOURCE_SET)
+        val quadrantExtension = registerConfigurationExtension()
 
         gradle.projectsEvaluated {
-            registerTask(createGenerateActivityClassNameConstantsTask(), variants)
+            val task = createGenerateActivityClassNameConstantsTask(quadrantExtension)
+            registerTask(task, variants)
         }
         addTargetDirectoryToSourceSet(mainSourceSet)
     }
@@ -68,10 +70,11 @@ class QuadrantPlugin : Plugin<Project> {
         return getByType(type.java)
     }
 
-    private fun Project.createGenerateActivityClassNameConstantsTask(): Task {
+    private fun Project.createGenerateActivityClassNameConstantsTask(
+        extension: QuadrantConfigurationExtension
+    ): Task {
         val taskType = GenerateActivityClassNameConstants::class.java
         val taskName = taskType.simpleName.decapitalize()
-        val extension = registerConfigurationExtension()
         return tasks.create(taskName, taskType) { task ->
             val rawModuleList = retrieveRawModuleList(this)
             task.apply {


### PR DESCRIPTION
Follows up #16 

## Current state

The `quadrantConfig` is not registered in the extension container even when the plugin is applied to the module.

<img width=420 src="https://github.com/gaelmarhic/Quadrant/assets/9159773/9e3fd6c7-d2e4-475e-83fb-3dd5904d5b40" />

The reason is that the extension configuration is now created and added to the container after the project is evaluated. It has to be done before the evaluation.

## Target state

`quadrantConfig` is recognized and works as described in README.md